### PR TITLE
Revert renaming of main RDS DB Instance.

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -6,9 +6,9 @@ output "iam_roles" {
 }
 
 output "rds_internal_tableau_endpoint" {
-  value = "${aws_db_instance.internal_reporting.endpoint}"
+  value = "${aws_db_instance.postgres.endpoint}"
 }
 
 output "rds_internal_tableau_address" {
-  value = "${aws_db_instance.internal_reporting.address}"
+  value = "${aws_db_instance.postgres.address}"
 }

--- a/rds.tf
+++ b/rds.tf
@@ -93,7 +93,7 @@ resource "aws_iam_role" "postgres" {
 EOF
 }
 
-resource "aws_db_instance" "internal_reporting" {
+resource "aws_db_instance" "postgres" {
   identifier                      = "postgres-${local.naming_suffix}"
   allocated_storage               = "${var.environment == "prod" ? "2000" : "300"}"
   storage_type                    = "gp2"
@@ -132,7 +132,7 @@ module "rds_alarms" {
   naming_suffix                = "${local.naming_suffix}"
   environment                  = "${var.naming_suffix}"
   pipeline_name                = "internal-tableau"
-  db_instance_id               = "${aws_db_instance.internal_reporting.id}"
+  db_instance_id               = "${aws_db_instance.postgres.id}"
   free_storage_space_threshold = 250000000000                     # 250GB free space
   read_latency_threshold       = 0.05                             # 50 milliseconds
   write_latency_threshold      = 1                                # 1 second
@@ -281,7 +281,7 @@ resource "aws_ssm_parameter" "rds_internal_tableau_service_password" {
 resource "aws_ssm_parameter" "rds_internal_tableau_postgres_endpoint" {
   name  = "rds_internal_tableau_postgres_endpoint"
   type  = "String"
-  value = "${aws_db_instance.internal_reporting.endpoint}"
+  value = "${aws_db_instance.postgres.endpoint}"
 }
 
 resource "aws_ssm_parameter" "rds_internal_tableau_dev_endpoint" {

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -72,16 +72,16 @@ class TestE2E(unittest.TestCase):
         self.assertEqual(self.result["root_modules"]["aws_security_group.internal_tableau_db"]["tags.Name"], "sg-db-internal-tableau-apps-preprod-dq")
 
     def test_rds_change_switch(self):
-        self.assertEqual(self.result["root_modules"]["aws_db_instance.internal_reporting"]["apply_immediately"], "false")
+        self.assertEqual(self.result["root_modules"]["aws_db_instance.postgres"]["apply_immediately"], "false")
 
     def test_rds_disk_size(self):
-        self.assertEqual(self.result["root_modules"]["aws_db_instance.internal_reporting"]["allocated_storage"], "2000")
+        self.assertEqual(self.result["root_modules"]["aws_db_instance.postgres"]["allocated_storage"], "2000")
 
     def test_rds_deletion_protection(self):
-        self.assertEqual(self.result["root_modules"]["aws_db_instance.internal_reporting"]["deletion_protection"], "true")
+        self.assertEqual(self.result["root_modules"]["aws_db_instance.postgres"]["deletion_protection"], "true")
 
     def test_rds_tags(self):
-        self.assertEqual(self.result["root_modules"]["aws_db_instance.internal_reporting"]["tags.Name"], "rds-postgres-internal-tableau-apps-preprod-dq")
+        self.assertEqual(self.result["root_modules"]["aws_db_instance.postgres"]["tags.Name"], "rds-postgres-internal-tableau-apps-preprod-dq")
 
     def test_ssm_rds_service_username(self):
         self.assertEqual(self.result["root_modules"]["aws_ssm_parameter.rds_internal_tableau_service_username"]["name"], "rds_internal_tableau_service_username")


### PR DESCRIPTION
Cannot rename RDS without destroying instance.