### PR TITLE
Activate actual licenses, not trial.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -109,8 +109,13 @@ echo "#Initialise TSM (finishes off Tableau Server install/config)"
 echo "#sourcing tableau server envs - because this script is run as root not tableau_srv"
 source /etc/profile.d/tableau_server.sh
 
-echo "#TSM active TRIAL license as tableau_srv"
-tsm licenses activate --trial -u $TAB_SRV_USER -p $TAB_SRV_PASSWORD
+#echo "#TSM active TRIAL license as tableau_srv"
+#tsm licenses activate --trial --username $TAB_SRV_USER --password $TAB_SRV_PASSWORD
+echo "#TSM active actual licenses as tableau_srv"
+tsm licenses activate --license-key "$TAB_PRODUCT_KEY_1" --username "$TAB_SRV_USER" --password "$TAB_SRV_PASSWORD"
+tsm licenses activate --license-key "$TAB_PRODUCT_KEY_2" --username "$TAB_SRV_USER" --password "$TAB_SRV_PASSWORD"
+tsm licenses activate --license-key "$TAB_PRODUCT_KEY_3" --username "$TAB_SRV_USER" --password "$TAB_SRV_PASSWORD"
+tsm licenses activate --license-key "$TAB_PRODUCT_KEY_4" --username "$TAB_SRV_USER" --password "$TAB_SRV_PASSWORD"
 
 echo "#TSM register user details"
 tsm register --file /tmp/install/tab_reg_file.json --username "$TAB_SRV_USER" --password "$TAB_SRV_PASSWORD"


### PR DESCRIPTION
Far fewer Blue instances are now spun up so the risk of burning licenses 
by terminating servers without deactivating liceses is much reduced.