### PR TITLE
Tableau Backup Cronjob Time

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -5,7 +5,7 @@ data "aws_ami" "int_tableau_linux" {
     name = "name"
 
     values = [
-      "dq-tableau-linux-243*",
+      "dq-tableau-linux-244*",
     ]
   }
 

--- a/data.tf
+++ b/data.tf
@@ -5,7 +5,7 @@ data "aws_ami" "int_tableau_linux" {
     name = "name"
 
     values = [
-      "dq-tableau-linux-244*",
+      "dq-tableau-linux-246*",
     ]
   }
 

--- a/main.tf
+++ b/main.tf
@@ -194,15 +194,6 @@ su -c "tabcmd --accepteula" - tableau_srv
 echo "#TSMCMD - initial user"
 tabcmd initialuser --server 'localhost:80' --username "$TAB_ADMIN_USER" --password "$TAB_ADMIN_PASSWORD"
 
-echo "#Checking environment: if notprod then move Tableau-Backup cron to daytime"
-if [ ${var.environment} == "notprod" ]; then
-  echo "#Notprod Env: Moving Tableau-backup cronjob to daytime in notprod"
-  echo "0 17 * * * source /home/tableau_srv/.bashrc; /home/tableau_srv/scripts/tableau-backup.sh" > /tmp/backupcron
-  crontab -u tableau_srv /tmp/backupcron
-else
-  echo "#Tableau-Backup cronjob remains at 7pm for environment ${var.environment}"
-fi
-
 # Always restore from green
 export BACKUP_LOCATION="$DATA_ARCHIVE_TAB_BACKUP_URL/green/"
 


### PR DESCRIPTION
Remove the editing of the cronjob that runs the Tableau backup because now the backups run at the same time (8am) in NotProd and Prod.