### PR TITLE
Attempt to get Tab Int Blue NotProd to run 2021.4.3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -112,17 +112,17 @@ echo "#Get latest code from git"
 su -c "git clone $TAB_INT_REPO_URL" - tableau_srv
 
 echo "#Initialise TSM (finishes off Tableau Server install/config)"
-/opt/tableau/tableau_server/packages/scripts.*/initialize-tsm --accepteula -f -a tableau_srv
+/opt/tableau/tableau_server/packages/scripts.*/initialize-tsm --accepteula --no-activation-service -f -a tableau_srv
 
 echo "#sourcing tableau server envs - because this script is run as root not tableau_srv"
 source /etc/profile.d/tableau_server.sh
 
-#echo "#TSM active TRIAL license as tableau_srv"
-#tsm licenses activate --trial --username $TAB_SRV_USER --password $TAB_SRV_PASSWORD
-echo "#TSM active actual licenses as tableau_srv"
-tsm licenses activate --license-key "$TAB_PRODUCT_KEY_1" --username "$TAB_SRV_USER" --password "$TAB_SRV_PASSWORD"
-tsm licenses activate --license-key "$TAB_PRODUCT_KEY_2" --username "$TAB_SRV_USER" --password "$TAB_SRV_PASSWORD"
-tsm licenses activate --license-key "$TAB_PRODUCT_KEY_3" --username "$TAB_SRV_USER" --password "$TAB_SRV_PASSWORD"
+echo "#TSM active TRIAL license as tableau_srv"
+tsm licenses activate --trial --username $TAB_SRV_USER --password $TAB_SRV_PASSWORD
+#echo "#TSM active actual licenses as tableau_srv"
+#tsm licenses activate --license-key "$TAB_PRODUCT_KEY_1" --username "$TAB_SRV_USER" --password "$TAB_SRV_PASSWORD"
+#tsm licenses activate --license-key "$TAB_PRODUCT_KEY_2" --username "$TAB_SRV_USER" --password "$TAB_SRV_PASSWORD"
+#tsm licenses activate --license-key "$TAB_PRODUCT_KEY_3" --username "$TAB_SRV_USER" --password "$TAB_SRV_PASSWORD"
 
 echo "#TSM register user details"
 tsm register --file /tmp/install/tab_reg_file.json --username "$TAB_SRV_USER" --password "$TAB_SRV_PASSWORD"


### PR DESCRIPTION
Do not use ATR - maybe that is causing activation to fail.
Activate TRIAL license instead of actual license - in case that is the 
cause.